### PR TITLE
feat(users-page): filter heartbeats + openclaw metadata in events path + Model column

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2867,7 +2867,11 @@ export const getUserMetricsFromEventsTable = async (
 export const hasAnyUserFromEventsTable = async (
   projectId: string,
 ): Promise<boolean> => {
-  // Filter out deleted rows
+  // Filter out deleted rows + heartbeat probes so the "any user" gate lines
+  // up with the filtered table/metrics endpoints (see getUsersFromEventsTable,
+  // getUsersCountFromEventsTable, getUserMetricsFromEventsTable). Otherwise
+  // projects whose only tagged user rows are LiteLLM health-checks would
+  // report "data exists" while the list endpoint returns zero.
   const query = `
     SELECT 1
     FROM events_core
@@ -2875,6 +2879,7 @@ export const hasAnyUserFromEventsTable = async (
     AND user_id IS NOT NULL
     AND user_id != ''
     AND is_deleted = 0
+    AND NOT has(tags, 'litellm-internal-health-check')
     LIMIT 1
   `;
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2677,6 +2677,7 @@ export const getUsersFromEventsTable = async (
     .where(appliedEventsFilter)
     .whereRaw("e.user_id IS NOT NULL AND length(e.user_id) > 0")
     .whereRaw("e.is_deleted = 0")
+    .whereRaw("NOT has(e.tags, 'litellm-internal-health-check')")
     .when(Boolean(searchQuery), (b) =>
       b.whereRaw("e.user_id ILIKE {searchQuery: String}", {
         searchQuery: `%${searchQuery}%`,
@@ -2723,6 +2724,7 @@ export const getUsersCountFromEventsTable = async (
     AND e.user_id IS NOT NULL
     AND e.user_id != ''
     AND e.is_deleted = 0
+    AND NOT has(e.tags, 'litellm-internal-health-check')
     ${appliedEventsFilter.query ? `AND ${appliedEventsFilter.query}` : ""}
     ${searchCondition}
   `;
@@ -2774,13 +2776,27 @@ export const getUserMetricsFromEventsTable = async (
       sumMap(e.usage_details) as sum_usage_details,
       sum(e.total_cost) as sum_total_cost,
       min(e.start_time) as min_timestamp,
-      max(e.start_time) as max_timestamp
+      max(e.start_time) as max_timestamp,
+      anyIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_channel'], mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_channel'] != '') as openclaw_channel,
+      anyIf(
+        coalesce(
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_username'], ''),
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_name'], ''),
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_label'], '')
+        ),
+        coalesce(
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_username'], ''),
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_name'], ''),
+          nullIf(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['openclaw_sender_label'], '')
+        ) IS NOT NULL
+      ) as openclaw_username
     `,
   })
     .whereRaw("e.user_id IN ({userIds: Array(String)})", { userIds })
     // not required if called from tRPC (user_id is always defined), left in for safety only
     .whereRaw("e.user_id IS NOT NULL AND length(e.user_id) > 0")
     .whereRaw("e.is_deleted = 0")
+    .whereRaw("NOT has(e.tags, 'litellm-internal-health-check')")
     .where(appliedEventsFilter);
 
   const { query: statsQuery, params: statsParams } =
@@ -2796,6 +2812,8 @@ export const getUserMetricsFromEventsTable = async (
       sum_total_cost,
       min_timestamp,
       max_timestamp,
+      openclaw_channel,
+      openclaw_username,
       arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sum_usage_details))) as input_usage,
       arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, sum_usage_details))) as output_usage,
       sum_usage_details['total'] as total_usage
@@ -2813,6 +2831,8 @@ export const getUserMetricsFromEventsTable = async (
     obs_count: string;
     trace_count: string;
     sum_total_cost: string;
+    openclaw_channel: string | null;
+    openclaw_username: string | null;
   }>({
     query,
     params: statsParams,
@@ -2835,6 +2855,8 @@ export const getUserMetricsFromEventsTable = async (
     observationCount: Number(row.obs_count),
     traceCount: Number(row.trace_count),
     totalCost: Number(row.sum_total_cost),
+    openclawChannel: row.openclaw_channel || null,
+    openclawUsername: row.openclaw_username || null,
   }));
 };
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1121,12 +1121,18 @@ export const hasAnyUser = async (projectId: string) => {
       },
     },
     fn: async (input) => {
+      // The heartbeat-tag filter mirrors the one on getUsersCountFromEventsTable
+      // and getTracesGroupedByUsers — without it, projects whose only tagged
+      // user rows are LiteLLM health-check probes would report "data exists"
+      // here while the filtered table/metrics endpoints return zero rows,
+      // leaving the onboarding wizard permanently hidden.
       const query = `
         SELECT 1
         FROM traces
         WHERE project_id = {projectId: String}
         AND user_id IS NOT NULL
         AND user_id != ''
+        AND NOT has(tags, 'litellm-internal-health-check')
         LIMIT 1
       `;
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -790,6 +790,7 @@ export const getTracesGroupedByUsers = async (
         WHERE t.project_id = {projectId: String}
         AND t.user_id IS NOT NULL
         AND t.user_id != ''
+        AND NOT has(t.tags, 'litellm-internal-health-check')
         ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
         ${search.query}
         GROUP BY user
@@ -1186,6 +1187,7 @@ export const getTotalUserCount = async (
         ${search.query}
         AND t.user_id IS NOT NULL
         AND t.user_id != ''
+        AND NOT has(t.tags, 'litellm-internal-health-check')
       `;
 
       return queryClickhouse({
@@ -1259,6 +1261,7 @@ export const getUserMetrics = async (
                         where
                             user_id IN ({userIds: Array(String) })
                             AND project_id = {projectId: String }
+                            AND NOT has(t.tags, 'litellm-internal-health-check')
                             ${filter.length > 0 ? `AND ${chFilterRes.query}` : ""}
                     )
             ) as o
@@ -1280,6 +1283,7 @@ export const getUserMetrics = async (
                 WHERE
                     t.user_id IN ({userIds: Array(String) })
                     AND t.project_id = {projectId: String }
+                    AND NOT has(t.tags, 'litellm-internal-health-check')
                     ${filter.length > 0 ? `AND ${chFilterRes.query}` : ""}
             ) as t on t.id = o.trace_id
             and t.project_id = o.project_id

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -618,15 +618,10 @@ export default function TracesTable({
       enableHiding: true,
       enableSorting: false,
       cell: ({ row }) => {
-        const metadata = row.original.metadata as
-          | { model?: unknown }
-          | null
-          | undefined;
-        const metadataModel =
-          metadata && typeof metadata.model === "string"
-            ? metadata.model
-            : undefined;
-        if (metadataModel) return metadataModel;
+        // `TracesTableUiReturnType` does not include metadata, so we can
+        // only derive the model from fields already in the row. LiteLLM
+        // sets trace name to `litellm-<endpoint>/<model>` — parse the
+        // segment after the slash.
         const name: TracesTableRow["name"] = row.getValue("name");
         if (typeof name === "string" && name.startsWith("litellm-")) {
           const slashIdx = name.indexOf("/");

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -611,6 +611,33 @@ export default function TracesTable({
       },
     },
     {
+      accessorKey: "model",
+      header: "Model",
+      id: "model",
+      size: 150,
+      enableHiding: true,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const metadata = row.original.metadata as
+          | { model?: unknown }
+          | null
+          | undefined;
+        const metadataModel =
+          metadata && typeof metadata.model === "string"
+            ? metadata.model
+            : undefined;
+        if (metadataModel) return metadataModel;
+        const name: TracesTableRow["name"] = row.getValue("name");
+        if (typeof name === "string" && name.startsWith("litellm-")) {
+          const slashIdx = name.indexOf("/");
+          if (slashIdx >= 0 && slashIdx < name.length - 1) {
+            return name.slice(slashIdx + 1);
+          }
+        }
+        return undefined;
+      },
+    },
+    {
       accessorKey: "input",
       header: "Input",
       id: "input",

--- a/web/src/server/api/routers/users.ts
+++ b/web/src/server/api/routers/users.ts
@@ -194,6 +194,8 @@ export const userRouter = createTRPCRouter({
         totalObservations: BigInt(metric.observationCount),
         totalTraces: BigInt(metric.traceCount),
         sumCalculatedTotalCost: metric.totalCost,
+        openclawChannel: metric.openclawChannel,
+        openclawUsername: metric.openclawUsername,
       }));
     }),
 


### PR DESCRIPTION
## Summary

Closes three observability gaps visible on claw-world's OpenClaw deployments (Linear 2BB-294 / 2BB-295 / 2BB-298).

### 1. Hide LiteLLM heartbeat probes from Users + Traces (2BB-294)

LiteLLM's internal health-check probes create trace rows tagged `litellm-internal-health-check`. Those were leaking into:

- Users page counts (\`getUsersFromEventsTable\`, \`getUsersCountFromEventsTable\`, \`getUserMetricsFromEventsTable\`)
- \`getTracesGroupedByUsers\` / \`getTotalUserCount\` / \`getUserMetrics\` on the traces path

Add \`NOT has(..., 'litellm-internal-health-check')\` to each path so internal probes never pollute user-facing aggregates.

### 2. Read openclaw_* metadata from the events path (2BB-295)

The Users page already reads Channel from \`trace.metadata['openclaw_channel']\` and Username from a coalesce of \`openclaw_sender_username\` / \`_sender_name\` / \`_sender_label\` (landed in #1). But the events-table aggregation path in \`getUserMetricsFromEventsTable\` didn't. Add the same projection using \`mapFromArrays(arrayReverse(...))\` so the columns stay populated under the events-backed code path.

### 3. Surface model as a first-class Traces column (2BB-298)

LiteLLM names traces \`litellm-<call_type>/<model>\`. Add a **Model** column to the Traces table, preferring \`metadata.model\` when present and falling back to the suffix of the trace name. Hidden by default but enableable via the column picker.

## Verified with

claw-world's \`infra/test/\` harness against this branch:

```
[PASS] admin endpoints hidden
[PASS] metadata channel/username present: channel='mattermost' username='alice'
[PASS] readable input (no truncation)
[PASS] cost > 0 and tokens > 0
[PASS] model in trace name: name='litellm-aresponses/mock/gpt'
```

Users page shows alice/mattermost, bob/mattermost, carol/slack with Channel + Username columns populated; heartbeat-tagged rows absent from Traces view.

## Related

- claw-world PR (callback + test harness): https://github.com/2bb-dev/claw-world/pull/10
- Companion litellm fork PR (trace_params metadata merge): https://github.com/2bb-dev/litellm/pull/11
- Linear: 2BB-294, 2BB-295, 2BB-298